### PR TITLE
PDF Parser

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PDF_DICTIONARY=../../data/pdf/dizionario_dialetto_materano.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__/
+.vscode/
 *.pyc
 report/
+venv/
+data/

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Benvenuti in **ChatMT**, un progetto di **Retrieval-Augmented Generation** dedic
 
 3. **Scarica il modello DeepSeek-R1-Distill-Qwen-7B** con Ollama:
    ```bash
-   ollama pull deepseek-r1:7b
+   ollama pull deepseek-r1:8b
    ```
 
 4. **Esegui il modello in test rapido**:
    ```bash
-   ollama run deepseek-r1:7b
+   ollama run deepseek-r1:8b
    ```
 
 5. **(Opzionale) Avvia Ollama in modalità server:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pdfplumber==0.11.5
+python-dotenv==1.0.1

--- a/src/ingestion/parse_pdf.py
+++ b/src/ingestion/parse_pdf.py
@@ -1,0 +1,131 @@
+import pdfplumber
+import re
+from dotenv import load_dotenv, find_dotenv
+from pathlib import Path
+import os
+
+def merge_splitted_words(lines):
+    """
+    Unisce righe che finiscono con '-' alla successiva,
+    rimuovendo il trattino di sillabazione. Esempio:
+    'abbatt-' + 'mento' -> 'abbattmento'.
+    """
+    merged = []
+    skip = False
+    for i in range(len(lines)):
+        if skip:
+            skip = False
+            continue
+
+        line = lines[i].rstrip()
+        # Se la riga finisce con '-' e c'è una riga successiva
+        if line.endswith('-') and (i + 1 < len(lines)):
+            next_line = lines[i + 1].lstrip()
+            new_line = line[:-1] + next_line
+            merged.append(new_line)
+            skip = True
+        else:
+            merged.append(line)
+    return merged
+
+def process_block(raw_text, vocab_list):
+    """
+    Elabora il testo di un singolo 'blocco' in cui ci si aspetta
+    la forma <termine>: <definizione...> con possibili enumerazioni 1), 2), ecc.
+    """
+    # Individua <termine> fino al primo ':', e tutto il resto come definizione
+    first_split = re.match(r"^([^:]+):\s*(.*)$", raw_text)
+    if not first_split:
+        return
+
+    termine = first_split.group(1).strip()
+    definizione_raw = first_split.group(2).strip()
+
+    # Gestione enumerazioni 1) 2) ...
+    parts = re.split(r"\d\)\s*", definizione_raw)
+    significati = [p.strip() for p in parts if p.strip()]
+
+    if not significati:
+        significati = [definizione_raw]
+
+    vocab_entry = {
+        'termine_dialetto': termine,
+        'significati': significati
+    }
+    vocab_list.append(vocab_entry)
+
+def parse_page_text(page_text, vocab_list):
+    """
+    Applica la logica di parsing su un testo estratto da una singola colonna.
+    - Splitta in righe
+    - 'Unisce' eventuali linee con trattino
+    - Accumula righe in blocchi <termine>: <definizione>
+    """
+    lines = page_text.split("\n")
+    lines = merge_splitted_words(lines)
+
+    # Pattern per riconoscere '<termine>: <definizione>'
+    term_pattern = re.compile(r"^([^:]+):\s*(.*)$", re.UNICODE)
+    
+    current_block = ""
+    for line in lines:
+        line = line.strip()
+        # Saltiamo righe vuote o possibili titoli
+        if (not line or
+            line.upper() == "DIZIONARIO MATERANO" or
+            re.match(r'^[A-Z]$', line)):
+            continue
+
+        match = term_pattern.match(line)
+        if match:
+            # Abbiamo trovato un nuovo 'termine: definizione'
+            # Processiamo il blocco accumulato finora
+            if current_block:
+                process_block(current_block, vocab_list)
+                current_block = ""
+            # Iniziamo il blocco con la riga corrente
+            current_block = line
+        else:
+            # Altrimenti estendiamo il blocco con la riga attuale
+            current_block += " " + line
+
+    # A fine colonna, processiamo l'ultimo blocco se presente
+    if current_block:
+        process_block(current_block, vocab_list)
+
+def parse_dizionario_pdf(pdf_path: str):
+    """
+    Legge un PDF strutturato a due colonne (sinistra, destra) per pagina.
+    Usa bounding box per estrarre separatamente ciascuna colonna,
+    quindi esegue la logica di parsing su entrambe.
+    
+    Restituisce una lista di dict con 'termine_dialetto' e 'significati'.
+    """
+    vocab_list = []
+    with pdfplumber.open(pdf_path) as pdf_file:
+        for page in pdf_file.pages:
+            left_text = page.within_bbox((0, 0, page.width / 2, page.height)).extract_text()
+            right_text = page.within_bbox((page.width / 2, 0, page.width, page.height)).extract_text()
+            # Parse colonna sinistra
+            parse_page_text(left_text, vocab_list)
+            # Parse colonna destra
+            parse_page_text(right_text, vocab_list)
+
+    return vocab_list
+
+def main():
+    # Carica il file .env (find_dotenv cerca il file a partire dalla cartella corrente verso l'alto)
+    load_dotenv(find_dotenv())
+    # Usa il percorso definito in .env, che è relativo alla posizione del file di esecuzione
+    pdf_path = Path(os.getenv("PDF_DICTIONARY"))
+    vocab = parse_dizionario_pdf(str(pdf_path))
+
+    # Ordina la lista in ordine alfabetico per 'termine_dialetto'
+    vocab.sort(key=lambda entry: entry['termine_dialetto'].lower())
+
+    # Mostra alcune voci d'esempio
+    for entry in vocab[:20]:
+        print(entry)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Description:**

- **Text Extraction from PDF:**  
  Utilized the **pdfplumber** library to extract text from the PDF containing the dictionary, which is organized in two columns. To ensure the correct reading order, the two columns are extracted separately using fixed bounding boxes.

- **Handling Hyphenated Words:**  
  Implemented the `merge_splitted_words` function to merge lines that end with a hyphen (`-`), properly reconstructing split words (e.g., "abbatt-" + "mento" becomes "abbattmento").

- **Accumulation and Parsing of Blocks:**  
  The code accumulates lines that belong to the same entry (block) and, using regular expressions, separates the dialect term (the part before the colon) from its definitions (the part after the colon). The definitions are further split based on enumerations (e.g., "1)", "2)") to handle cases where an entry has multiple meanings.

- **Handling Titles and Irrelevant Lines:**  
  Implemented logic to ignore empty lines, titles (e.g., "DIZIONARIO MATERANO") and single letters that indicate the beginning of a new section (e.g., "A", "B", etc.).

- **Path Configuration via .env:**  
  The path to the PDF file is now managed through a `.env` file located at the root of the project, with the variable `PDF_PATH` set to a relative path (e.g., `../../data/pdf/dizionario_dialetto_materano.pdf`). This approach makes the code more portable and easily configurable without hardcoding absolute paths.

- **Output and Verification:**  
  The script prints sample entries to facilitate the verification of the parsing process, ensuring that the terms and definitions are correctly extracted.
